### PR TITLE
changed repo_name

### DIFF
--- a/colab_ssh/init_git.py
+++ b/colab_ssh/init_git.py
@@ -22,7 +22,8 @@ def init_git(repositoryUrl,
             callback=parse_folder_name
     )
 
-    repo_name = os.path.basename(repositoryUrl).rstrip(".git") 
+    repo_name = os.path.basename(repositoryUrl)
+    repo_name, _ = os.path.splitext(repo_name)
 
     # Checkout the branch
     os.system(f'cd {repo_name} && git checkout {branch}')


### PR DESCRIPTION
Changed the way the repository name is extracted from the git repositoryUrl

Before:
```python
repositoryUrl = 'https://github.com/flych3r/dive-into-deep-learning.git'
repo_name = os.path.basename(repositoryUrl).rstrip(".git") 
print(repo_name)
>>> dive-into-deep-learnin
```
Correct behaviour:
```python
repositoryUrl = 'https://github.com/flych3r/dive-into-deep-learning.git'
repo_name = os.path.basename(repositoryUrl)
repo_name, _ = os.path.splitext(repo_name)
print(repo_name)
>>> dive-into-deep-learning
```

Closes #23 