### PR TITLE
Improved verbose output and increasing sleep times

### DIFF
--- a/colab_ssh/launch_ssh_cloudflared.py
+++ b/colab_ssh/launch_ssh_cloudflared.py
@@ -56,24 +56,30 @@ def launch_ssh_cloudflared(
 
     extra_params = []
     info = None
+
+    popen_command = f'./cloudflared tunnel --url ssh://localhost:22 --logfile ./cloudflared.log --metrics localhost:45678 {" ".join(extra_params)}'
+    preexec_fn = None
+    if prevent_interrupt:
+        popen_command = 'nohup ' + popen_command
+        preexec_fn = os.setpgrp
+    popen_command = shlex.split(popen_command)
+    sleep_time = 2.0
     # Create tunnel and retry if failed
     for i in range(10):
-        popen_command = f'./cloudflared tunnel --url ssh://localhost:22 --logfile ./cloudflared.log --metrics localhost:45678 {" ".join(extra_params)}'
-        preexec_fn = None
-        if prevent_interrupt: 
-            popen_command = 'nohup ' + popen_command
-            preexec_fn = os.setpgrp
-        proc = Popen(shlex.split(popen_command), stdout=PIPE, preexec_fn=preexec_fn)
-        if verbose: print(f"Cloudflared process: PID={proc.pid}")
-        time.sleep(3)
+        proc = Popen(popen_command, stdout=PIPE, preexec_fn=preexec_fn)
+        if verbose:
+            print(f"DEBUG: Cloudflared process: PID={proc.pid}")
+        time.sleep(sleep_time)
         try:
             info = get_argo_tunnel_config()
             break
-        except:
+        except Exception as e:
             os.kill(proc.pid, signal.SIGKILL)
             if verbose:
-                print(f"DEBUG: Killing {proc.pid}. Retrying again ...")
-            continue
+                print(f"DEBUG: {e.args[0]}")
+                print(f"DEBUG: Killing {proc.pid}. Retrying...")
+        # Increase the sleep time and try again
+        sleep_time *= 1.5
 
     if verbose:
         print("DEBUG:", info)
@@ -96,7 +102,7 @@ def launch_ssh_cloudflared(
             ProxyCommand <PUT_THE_ABSOLUTE_CLOUDFLARE_PATH_HERE> access ssh --hostname %h
 
 *) Connect with SSH Terminal
-    To connect using your terminal, type this command: 
+    To connect using your terminal, type this command:
         ssh {domain}
 
 *) Connect with VSCode Remote SSH


### PR DESCRIPTION
If cloudflared is slow for some reason, increase the sleep time exponentially, 2s, 3s, 4.5s, 6.8s, etc. Sometimes the default sleep time of 3 seconds is too short so for each retry it should be increased. I also added more debug output to help with future issues.