### PR TITLE
Staging: Improved verbose output and increasing sleep times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Improve verbose output and increasing sleep times (@bjourne)
 - When cloning private repositories, the message "Cloned the repo successfully" doesn't show up anymore.
 - Check if the repository is public, before cloning it.
 - Ask for password if the repository is private (in other words not found in the remote)

--- a/colab_ssh/launch_ssh_cloudflared.py
+++ b/colab_ssh/launch_ssh_cloudflared.py
@@ -57,13 +57,17 @@ def launch_ssh_cloudflared(
     extra_params = []
     info = None
 
+    # Prepare the cloudflared command
     popen_command = f'./cloudflared tunnel --url ssh://localhost:22 --logfile ./cloudflared.log --metrics localhost:45678 {" ".join(extra_params)}'
     preexec_fn = None
     if prevent_interrupt:
         popen_command = 'nohup ' + popen_command
         preexec_fn = os.setpgrp
     popen_command = shlex.split(popen_command)
+
+    # Initial sleep time
     sleep_time = 2.0
+
     # Create tunnel and retry if failed
     for i in range(10):
         proc = Popen(popen_command, stdout=PIPE, preexec_fn=preexec_fn)
@@ -76,7 +80,7 @@ def launch_ssh_cloudflared(
         except Exception as e:
             os.kill(proc.pid, signal.SIGKILL)
             if verbose:
-                print(f"DEBUG: {e.args[0]}")
+                print(f"DEBUG: Exception: {e.args[0]}")
                 print(f"DEBUG: Killing {proc.pid}. Retrying...")
         # Increase the sleep time and try again
         sleep_time *= 1.5

--- a/colab_ssh/launch_ssh_cloudflared.py
+++ b/colab_ssh/launch_ssh_cloudflared.py
@@ -56,24 +56,30 @@ def launch_ssh_cloudflared(
 
     extra_params = []
     info = None
+
+    popen_command = f'./cloudflared tunnel --url ssh://localhost:22 --logfile ./cloudflared.log --metrics localhost:45678 {" ".join(extra_params)}'
+    preexec_fn = None
+    if prevent_interrupt:
+        popen_command = 'nohup ' + popen_command
+        preexec_fn = os.setpgrp
+    popen_command = shlex.split(popen_command)
+    sleep_time = 2.0
     # Create tunnel and retry if failed
     for i in range(10):
-        popen_command = f'./cloudflared tunnel --url ssh://localhost:22 --logfile ./cloudflared.log --metrics localhost:45678 {" ".join(extra_params)}'
-        preexec_fn = None
-        if prevent_interrupt: 
-            popen_command = 'nohup ' + popen_command
-            preexec_fn = os.setpgrp
-        proc = Popen(shlex.split(popen_command), stdout=PIPE, preexec_fn=preexec_fn)
-        if verbose: print(f"Cloudflared process: PID={proc.pid}")
-        time.sleep(3)
+        proc = Popen(popen_command, stdout=PIPE, preexec_fn=preexec_fn)
+        if verbose:
+            print(f"DEBUG: Cloudflared process: PID={proc.pid}")
+        time.sleep(sleep_time)
         try:
             info = get_argo_tunnel_config()
             break
-        except:
+        except Exception as e:
             os.kill(proc.pid, signal.SIGKILL)
             if verbose:
-                print(f"DEBUG: Killing {proc.pid}. Retrying again ...")
-            continue
+                print(f"DEBUG: {e.args[0]}")
+                print(f"DEBUG: Killing {proc.pid}. Retrying...")
+        # Increase the sleep time and try again
+        sleep_time *= 1.5
 
     if verbose:
         print("DEBUG:", info)
@@ -96,7 +102,7 @@ def launch_ssh_cloudflared(
             ProxyCommand <PUT_THE_ABSOLUTE_CLOUDFLARE_PATH_HERE> access ssh --hostname %h
 
 *) Connect with SSH Terminal
-    To connect using your terminal, type this command: 
+    To connect using your terminal, type this command:
         ssh {domain}
 
 *) Connect with VSCode Remote SSH

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="colab_ssh",
-    version="0.3.14",
+    version="0.3.15",
     author="Wassim Benzarti",
     author_email="m.wassim.benzarti@gmail.com",
     description="Google colab SSH connector",


### PR DESCRIPTION
This is the pull request #72 from @bjourne.

**Why it's been transferred to the branch `staging` ?**
Because Github doesn't give access to secrets of this repository from other forked repositories. Secrets are required during the tests of colab-ssh running inside Github Actions.