### PR TITLE
Restart SSH instead of starting it every time the configuration changes

### DIFF
--- a/colab_ssh/launch_ssh_cloudflared.py
+++ b/colab_ssh/launch_ssh_cloudflared.py
@@ -53,7 +53,7 @@ def launch_ssh_cloudflared(
     expose_env_variable("TPU_NAME")
     expose_env_variable("XRT_TPU_CONFIG")
 
-    os.system('service ssh start')
+    os.system('service ssh restart')
 
     extra_params = []
     info = None


### PR DESCRIPTION
Restart SSH instead of starting it every time the configuration changes. This is relevant if the OpenSSH is already started.

Fixes #105